### PR TITLE
feat(back-end): add route to get all categories

### DIFF
--- a/back-end/controllers/category-controller.js
+++ b/back-end/controllers/category-controller.js
@@ -1,0 +1,19 @@
+const { Prisma, PrismaClient } = require('@prisma/client')
+
+const prisma = new PrismaClient({ log: ['query'] })
+
+const categoryController = {
+  // Get all categories
+  // URL: /categories
+  getCategories: async (req, res, next) => {
+    try {
+      const categories = await prisma.category.findMany()
+
+      res.json(categories)
+    } catch (error) {
+      next(error)
+    }
+  },
+}
+
+module.exports = categoryController

--- a/back-end/routes/index.js
+++ b/back-end/routes/index.js
@@ -3,8 +3,10 @@ const router = express.Router()
 
 const users = require('./modules/users')
 const records = require('./modules/records')
+const categories = require('./modules/categories')
 
 router.use('/users', users)
 router.use('/records', records)
+router.use('/categories', categories)
 
 module.exports = router

--- a/back-end/routes/modules/categories.js
+++ b/back-end/routes/modules/categories.js
@@ -1,0 +1,8 @@
+const express = require('express')
+const router = express.Router()
+
+const categoryController = require('../../controllers/category-controller')
+
+router.get('/', categoryController.getCategories)
+
+module.exports = router


### PR DESCRIPTION
This is the feature that meets issue #9 Need a route to get all categories.
- Feature: get all categories, including `id`, `main category` and `sub category`
- URL: `/categories`
- Pass thunder client test