### PR TITLE
fix: remove squash_and_merge.jpg:Zone.Identifier (no idea why it exists)

### DIFF
--- a/assets/squash_and_merge.jpg:Zone.Identifier
+++ b/assets/squash_and_merge.jpg:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-LastWriterPackageFamilyName=Microsoft.ScreenSketch_8wekyb3d8bbwe
-ZoneId=3


### PR DESCRIPTION
- Remove the `squash_and_merge.jpg:Zone.Identifier`
- fix #24 