### PR TITLE
be standardize error situations

### DIFF
--- a/back-end/controllers/record-controller.js
+++ b/back-end/controllers/record-controller.js
@@ -114,8 +114,9 @@ const recordController = {
         },
       })
 
-      // !theRecord: {}
-      if (theRecord === 'null') {
+      // theRecord should be {}, but somehow it's null
+      // if (Object.keys(theRecord).length === 0)
+      if (!theRecord) {
         return res.status(400).json({
           type: 'Put record failed',
           title: 'Record not exist',
@@ -182,8 +183,10 @@ const recordController = {
           id: recordId,
         },
       })
-      // !theRecord: {}
-      if (theRecord === 'null') {
+
+      // theRecord should be {}, but somehow it's null
+      // if (Object.keys(theRecord).length === 0)
+      if (!theRecord) {
         return res.status(400).json({
           type: 'Delete record failed',
           title: 'Record not exist',

--- a/back-end/controllers/user-controller.js
+++ b/back-end/controllers/user-controller.js
@@ -8,10 +8,30 @@ const userController = {
   // User log in
   // URL: post /users/logIn
   logIn: async (req, res, next) => {
-    // Check if there are email and password in req.body
     const { email, password } = req.body
+
+    // Check if there are email and password in req.body
     if (!email || !password)
-      return res.status(400).json(`missing user's email or password`)
+      return res.status(400).json({
+        type: 'Login failed',
+        title: 'Require email or password',
+        field_errors: {
+          email: 'required',
+          password: 'required',
+        },
+      })
+
+    // Check data type of the email and password
+    if (typeof email !== 'string' || typeof password !== 'string') {
+      return res.status(400).json({
+        type: 'Login failed',
+        title: 'Incorrect data type',
+        field_errors: {
+          email: 'string',
+          password: 'string',
+        },
+      })
+    }
 
     try {
       // Check if the current user has registered an account
@@ -21,12 +41,16 @@ const userController = {
         },
       })
 
-      if (!user)
-        return res
-          .status(400)
-          .json(
-            'Incorrect email address or this user has not registered an account.'
-          )
+      if (!user) {
+        return res.status(400).json({
+          type: 'Login failed',
+          title: 'Incorrect email or password',
+          field_errors: {
+            email: 'incorrect',
+            password: 'incorrect',
+          },
+        })
+      }
 
       // Sign a token
       const token = jwt.sign(req.user, process.env.JWT_SECRET, {
@@ -44,11 +68,32 @@ const userController = {
   // User register an account
   // URL: post /users/register
   register: async (req, res, next) => {
-    try {
-      const { email, password } = req.body
-      if (!email || !password)
-        return res.status(400).json('missing email or password')
+    const { email, password } = req.body
 
+    // Check if there are email and password in req.body
+    if (!email || !password)
+      return res.status(400).json({
+        type: 'Register failed',
+        title: 'Require email or password',
+        field_errors: {
+          email: 'required',
+          password: 'required',
+        },
+      })
+
+    // Check data type of the email and password
+    if (typeof email !== 'string' || typeof password !== 'string') {
+      return res.status(400).json({
+        type: 'Register failed',
+        title: 'Incorrect data type',
+        field_errors: {
+          email: 'string',
+          password: 'string',
+        },
+      })
+    }
+
+    try {
       // Check if the email address has been registered
       const user = await prisma.user.findUnique({
         where: {
@@ -60,7 +105,13 @@ const userController = {
           data: { email, password: await bcrypt.hash(password, 10) },
         })
       } else if (user) {
-        return res.status(400).json('this email has been registered')
+        return res.status(400).json({
+          type: 'Register failed',
+          title: 'Email is used',
+          field_errors: {
+            email: 'used',
+          },
+        })
       }
 
       return res.status(201).end()

--- a/back-end/prisma/schema.prisma
+++ b/back-end/prisma/schema.prisma
@@ -2,7 +2,8 @@
 // learn more about it in the docs: https://pris.ly/d/prisma-schema
 
 generator client {
-  provider = "prisma-client-js"
+  provider      = "prisma-client-js"
+  binaryTargets = ["native", "darwin"]
 }
 
 datasource db {

--- a/back-end/prisma/schema.prisma
+++ b/back-end/prisma/schema.prisma
@@ -2,8 +2,7 @@
 // learn more about it in the docs: https://pris.ly/d/prisma-schema
 
 generator client {
-  provider      = "prisma-client-js"
-  binaryTargets = ["native", "darwin"]
+  provider = "prisma-client-js"
 }
 
 datasource db {

--- a/back-end/src/swagger.json
+++ b/back-end/src/swagger.json
@@ -41,7 +41,7 @@
           "200": {
             "description": "successfully login and return token",
             "content": {
-              "application/json": {
+              "token": {
                 "example": {
                   "token": "4687864541635fwf3q2rfewafoiqu3whjrfuie.chiwfhoiejfoewijfp346846"
                 }
@@ -51,12 +51,35 @@
           "400": {
             "description": "Client side error",
             "content": {
-              "application/json": {
-                "example": {
-                  "Error Situations": "Error Message",
-                  "Wrong data type of the password": "data type of the password should be String.",
-                  "Miss email or password in req.body": "missing email or password",
-                  "There is no the eamil address in database": "incorrect email address or this user has not registered an account."
+              "errors": {
+                "schema": {
+                  "example": {
+                    "code": "400",
+                    "type": "Login failed",
+                    "errors": [
+                      {
+                        "title": "Require email or password",
+                        "field_errors": {
+                          "email": "required",
+                          "password": "required"
+                        }
+                      },
+                      {
+                        "title": "Incorrect data type",
+                        "field_errors": {
+                          "email": "string",
+                          "password": "string"
+                        }
+                      },
+                      {
+                        "title": "Incorrect email or password",
+                        "field_errors": {
+                          "email": "incorrect",
+                          "password": "incorrect"
+                        }
+                      }
+                    ]
+                  }
                 }
               }
             }
@@ -93,12 +116,34 @@
           "400": {
             "description": "Client side error",
             "content": {
-              "application/json": {
-                "example": {
-                  "Error Situations": "Error Message",
-                  "Wrong data type of password": "data type of the password should be String.",
-                  "Miss email or password in req.body": "missing email or password",
-                  "The email has already been registered": "the email has been registered"
+              "errors": {
+                "schema": {
+                  "example": {
+                    "code": "400",
+                    "type": "Register failed",
+                    "errors": [
+                      {
+                        "title": "Require email or password",
+                        "field_errors": {
+                          "email": "required",
+                          "password": "required"
+                        }
+                      },
+                      {
+                        "title": "Incorrect data type",
+                        "field_errors": {
+                          "email": "string",
+                          "password": "string"
+                        }
+                      },
+                      {
+                        "title": "Email is used",
+                        "field_errors": {
+                          "email": "used"
+                        }
+                      }
+                    ]
+                  }
                 }
               }
             }

--- a/back-end/src/swagger.json
+++ b/back-end/src/swagger.json
@@ -215,6 +215,37 @@
         "responses": {
           "201": {
             "description": "user successfully created a record"
+          },
+          "400": {
+            "description": "Client side error",
+            "content": {
+              "errors": {
+                "schema": {
+                  "example": {
+                    "code": "400",
+                    "type": "Post record failed",
+                    "errors": [
+                      {
+                        "title": "Require reocrd title, amount or categoryId",
+                        "field_errors": {
+                          "record": "required",
+                          "amount": "required",
+                          "categoryId": "required"
+                        }
+                      },
+                      {
+                        "title": "Incorrect data type",
+                        "field_errors": {
+                          "title": "string",
+                          "amount": "number",
+                          "categoryId": "number"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
           }
         },
         "security": [
@@ -268,12 +299,50 @@
           "400": {
             "description": "Client side error",
             "content": {
-              "application/json": {
-                "example": {
-                  "Error Situations": "Error Message",
-                  "Miss title or amount or categoryId in req.body": "missing title or amount or category id to update this record",
-                  "There is no the record data in ": "the record does not exist",
-                  "The record doesn't belong to the current user": "this record does not belong to the current user"
+              "errors": {
+                "schema": {
+                  "example": {
+                    "code": "400",
+                    "type": "Put record failed",
+                    "errors": [
+                      {
+                        "tile": "Require reocrd id",
+                        "field_errors": {
+                          "recordId": "required"
+                        }
+                      },
+                      {
+                        "title": "Require reocrd id, title, amount or categoryId",
+                        "field_errors": {
+                          "recordId": "required",
+                          "title": "required",
+                          "amount": "required",
+                          "categoryId": "required"
+                        }
+                      },
+                      {
+                        "title": "Incorrect data type",
+                        "field_errors": {
+                          "recordId": "number",
+                          "title": "string",
+                          "amount": "number",
+                          "categoryId": "number"
+                        }
+                      },
+                      {
+                        "title": "Record not exist",
+                        "field_errors": {
+                          "record": "not exist"
+                        }
+                      },
+                      {
+                        "title": "Invalid user",
+                        "field_errors": {
+                          "userId": "not theRecord.userId"
+                        }
+                      }
+                    ]
+                  }
                 }
               }
             }
@@ -308,11 +377,38 @@
           "400": {
             "description": "Client side error",
             "content": {
-              "application/json": {
-                "example": {
-                  "Error Situations": "Error Message",
-                  "There is no the record data in ": "the record does not exist",
-                  "The record doesn't belong to the current user": "this record does not belong to the current user"
+              "errors": {
+                "schema": {
+                  "example": {
+                    "code": "400",
+                    "type": "Delete record failed",
+                    "errors": [
+                      {
+                        "tile": "Require reocrd id",
+                        "field_errors": {
+                          "recordId": "required"
+                        }
+                      },
+                      {
+                        "title": "Incorrect data type",
+                        "field_errors": {
+                          "recordId": "number"
+                        }
+                      },
+                      {
+                        "title": "Record not exist",
+                        "field_errors": {
+                          "record": "not exist"
+                        }
+                      },
+                      {
+                        "title": "Invalid user",
+                        "field_errors": {
+                          "userId": "not theRecord.userId"
+                        }
+                      }
+                    ]
+                  }
                 }
               }
             }


### PR DESCRIPTION
- Standardize error situations on each route, the form is: 
``` js
res.status(code).json({
  type: 'categorize error',
  title: 'brief and human-readable description',
  field_errors: {
    key-value pair to point out which the error fields 
  }
})
```

- example:
```js
res.status(400).json({
  type: 'Put record failed',
  title: 'Incorrect data type',
  field_errors: {
    recordId: 'number',
    title: 'string',
    amount: 'number',
    categoryId: 'number'
  }
})
```

- Rather than send a long sentence to the front end, pointing out the error fields is an easier way to let the front-end partner know what happened to the sent data.
- Refer to the article linked below and change to my own version for this project
- Ref: [Best Practices for REST API Error Handling](https://www.baeldung.com/rest-api-error-handling-best-practices#3-more-detailed-responses)