### PR TITLE
build: hope this time can really fix it

### DIFF
--- a/front-end/svelte.config.js
+++ b/front-end/svelte.config.js
@@ -13,7 +13,8 @@ const config = {
 			hooks: {
 				server: 'src/hooks.server'
 			}
-		}
+		},
+		outDir: 'public'
 	}
 };
 

--- a/front-end/tsconfig.json
+++ b/front-end/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "./.svelte-kit/tsconfig.json",
+	"extends": "./public/tsconfig.json",
 	"compilerOptions": {
 		"allowJs": true,
 		"checkJs": true,


### PR DESCRIPTION
According to the Vercel error message in both Preview & Production, I add `outDir: 'public'` in `svelte.config.js` & correct extend paths in `tsconfig.json` to `./publice` instead of `./.svelte-kit`